### PR TITLE
Add Template layout for Home page

### DIFF
--- a/components/Home/index.tsx
+++ b/components/Home/index.tsx
@@ -1,0 +1,19 @@
+const Home = () => {
+  return (
+    <div className="min-h-screen flex justify-center items-center">
+      <main>
+        <div className="flex justify-between items-center flex-col">
+          <img className="rounded-full w-60 sm:w-56 md:w-52 lg:w-48" src="/logo.jpg" />
+          <h1 className="title mt-9 text-4xl sm:text-5xl md:text-6xl lg:text-7xl">
+            FingerStyle Taiwan
+          </h1>
+        </div>
+        <div className="text-center text-gray-500 text-2xl mt-9">
+          coming soon...
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default Home;

--- a/components/shared/Template/index.tsx
+++ b/components/shared/Template/index.tsx
@@ -1,0 +1,32 @@
+import Head from 'next/head'
+import { ReactNode } from 'react';
+
+interface TemplateProps {
+  children: ReactNode;
+}
+
+const Template = (props: TemplateProps) => {
+  const { children } = props;
+  return (
+    <div>
+      <Head>
+        <title>FingerStyle Taiwan</title>
+
+        <meta name="description" content="fingerstyle taiwan group" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1" />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="FingerStyle Taiwan" />
+        <meta property="og:description" content="fingerstyle taiwan group" />
+        <meta property="og:image" content="/logo.jpg" />
+        <meta property="og:url" content="https://www.fingerstyletaiwan.com" />
+        <meta property="og:site_name" content="FingerStyle Taiwan" />
+
+        <link rel="icon" href="/logo.jpg" />
+      </Head>
+      {children}
+    </div>
+  );
+}
+
+export default Template;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,29 +1,13 @@
 import type { NextPage } from 'next'
-import Head from 'next/head'
+import Template from 'components/shared/Template'
+import Home from 'components/Home'
 
-const Home: NextPage = () => {
+const HomePage: NextPage = () => {
   return (
-    <div className="min-h-screen flex justify-center items-center">
-      <Head>
-        <title>FingerStyle Taiwan</title>
-        <meta name="description" content="fingerstyle taiwan group" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1"></meta>
-        <link rel="icon" href="/logo.jpg" />
-      </Head>
-
-      <main>
-        <div className="flex justify-between items-center flex-col">
-          <img className="rounded-full w-60 sm:w-56 md:w-52 lg:w-48" src="/logo.jpg" />
-          <h1 className="title mt-9 text-4xl sm:text-5xl md:text-6xl lg:text-7xl">
-            FingerStyle Taiwan
-          </h1>
-        </div>
-        <div className="text-center text-gray-500 text-2xl mt-9">
-          coming soon...
-        </div>
-      </main>
-    </div>
+    <Template>
+      <Home />
+    </Template>
   )
 }
 
-export default Home
+export default HomePage

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     "./node_modules/flowbite-react/**/*.js",
     "./pages/**/*.{ts,tsx}",
     "./public/**/*.html",
+    "./components/**/*.{ts,tsx}",
   ],
   plugins: [
     require("flowbite/plugin")


### PR DESCRIPTION

## 描述

For SEO, add meta info to head and make it as a template layout


## 檢查清單:

- [x] add components folder items to tailwind config
- [x] add Template component for basic layout
- [x] add Home page component
- [x] add Template and Home page into index page   
