### PR TITLE
[DON'T MERGE]👷 feat: add build and lint steps in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: main workflow
-on: push
+on: 
+  push
+  pull_request:
+    type: opened
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: main workflow
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn build
+      - uses: actions/cache@v2
+        id: cache-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - run: yarn lint


### PR DESCRIPTION

## 描述
Issue #12 ，目前還沒有 testing 流程，先整併 `build` 與 `lint` 步驟到 GitHub Actions CI process 中，並且實作 CI Build Cache ([ref1,](https://nextjs.org/docs/advanced-features/ci-build-caching),  [ref2](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows))

## 變更類型

- [X] 新功能（增加功能的非破壞性更改

## 檢查清單:
需要 create PR 後才能 trigger workflow，在確定功能正確前不會移除 [DON'T MERGE] 標籤

