### PR TITLE
✨ feat: github actions ci main workflow with build and lint steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: main workflow
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+            ${{ github.workspace }}/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn build
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: |
+            ./node_modules
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
+      - run: yarn lint

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,9 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   output: 'standalone',
-}
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
## 描述

- In Issue #12 , we need to add github actions which run lint and test, because testing is not integrated yet, I only add `build` and `lint` steps in this PR
- the actions will be trigger when
   1. open pull request  and following push
   2. code been merge to main branch (we can add another branch here)
- implement `yarn` cache and `next` cache ([ref](https://nextjs.org/docs/advanced-features/ci-build-caching)) to optimize build performance
- change `next.config.js` to disabled lint in `build` step because we already have independent `lint` step

## 變更類型

- [X] 新功能（增加功能的非破壞性更改


## Note
- I have test workflow [in my own repo](https://github.com/Fingerstyle-Taiwan/nextjs-frontend/pull/19#issue-1400931391)
- Why the PR in my repo will trigger the action but it does not here ? Is the trigger condition need to be fixed ? (update: seems like we need to open [this setting](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-forks-of-private-repositories) ? ([stack-overflow reference](https://stackoverflow.com/questions/73314842/cannot-trigger-github-actions-while-pull-request-from-a-fork-repo))) 